### PR TITLE
Revamped Site

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -1,13 +1,13 @@
-import { defineConfig } from 'vitepress'
+import { defineConfig } from "vitepress";
 
 // https://vitepress.dev/reference/site-config
 export default defineConfig({
-  base: '/tessera-official-website/',
+  base: "/tessera-official-website/",
   title: "Tessera",
   description: "A declarative, immediate-mode UI framework for Rust",
   head: [
     [
-      'script',
+      "script",
       {},
       `
       (function() {
@@ -20,41 +20,43 @@ export default defineConfig({
           }
         }
       })();
-      `
-    ]
+      `,
+    ],
   ],
-  
+
   locales: {
     root: {
-      label: 'English',
+      label: "English",
     },
     zh: {
-      label: '简体中文',
-      lang: 'zh-CN',
-      link: '/zh/',
-    }
+      label: "简体中文",
+      lang: "zh-CN",
+      link: "/zh/",
+    },
   },
 
   themeConfig: {
     // https://vitepress.dev/reference/default-theme-config
     nav: [
-      { text: 'Home', link: '/' },
-      { text: 'Guides', link: '/quick-start/what-is-tessera' },
+      { text: "Home", link: "/" },
+      { text: "Guide", link: "/guide/getting-started" },
+      { text: "About", link: "/about/about" },
     ],
 
     sidebar: [
       {
-        text: 'Quick Start',
+        text: "Docs",
         items: [
-          { text: 'What is Tessera?', link: '/quick-start/what-is-tessera' },
-        ]
-      }
+          { text: "Getting Started", link: "/guide/getting-started" },
+          { text: "What is Tessera?", link: "/guide/what-is-tessera" },
+        ],
+      },
     ],
 
     socialLinks: [
-      { icon: 'github', link: 'https://github.com/tessera-ui/tessera' }
+      { icon: "github", link: "https://github.com/tessera-ui/tessera" },
     ],
 
-    i18nRouting: true
+    i18nRouting: true,
   },
-})
+});

--- a/docs/about/about.md
+++ b/docs/about/about.md
@@ -1,0 +1,6 @@
+---
+layout: home
+
+hero:
+  name: "About Tessera"
+---

--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -1,0 +1,6 @@
+# Getting Started
+
+## Installation
+
+### Prerequisites
+- The [Rust](https://www.rust-lang.org) programming language

--- a/docs/guide/what-is-tessera.md
+++ b/docs/guide/what-is-tessera.md
@@ -1,0 +1,157 @@
+# Tessera UI Framework
+
+Tessera is a declarative, immediate-mode UI framework for Rust that emphasizes performance, flexibility, and extensibility through a functional approach and pluggable shader system.
+Architecture Overview
+
+Tessera’s architecture is built around several core concepts:
+
+- Declarative Components: UI components are defined as functions with the `#[tessera]` macro
+- Immediate Mode: The UI is rebuilt every frame, ensuring consistency and simplicity
+- Pluggable Shaders: Custom WGPU shaders are first-class citizens for advanced visual effects
+- Parallel Processing: Core operations like measurement utilize parallel computation
+- Explicit State Management: Components are stateless with explicit state passing
+
+## Getting Started by Developer Level
+🟢 **Beginner Users** - Building Basic Applications
+
+If you’re new to Tessera and want to build applications using existing components:
+
+Start with these modules:
+- `renderer` - Core renderer and application lifecycle management
+- `Dp`, `Px` - Basic measurement units for layouts
+- `Color` - Color system for styling components
+
+Key concepts to understand:
+- How to set up a `Renderer` and run your application
+- Using `tessera_basic_components` for common UI elements
+- Basic layout with `row`, `column`, and `surface` components
+
+```rust
+use tessera_ui::{Renderer, Color, Dp};
+use tessera_ui_basic_components::*;
+use tessera_ui_macros::tessera;
+
+#[tessera]
+fn my_app() {
+    surface(
+        SurfaceArgs {
+            color: Color::WHITE,
+            padding: Dp(20.0),
+            ..Default::default()
+        },
+        None,
+        || text("Hello, Tessera!"),
+    );
+}
+```
+
+🟡 **Intermediate Users** - Custom Layout and Interaction
+
+For developers who want to create custom components and handle complex layouts:
+
+Essential functions and types:
+- `measure_node` - Measure child component sizes with constraints
+- `place_node` - Position child components in the layout
+- `StateHandlerFn` - Handle user interactions and state changes
+- `Constraint`, `DimensionValue` - Layout constraint system
+- `ComputedData` - Return computed size and layout information
+
+Key concepts:
+- Understanding the measurement and placement phase
+- Creating custom layout algorithms
+- Managing component state through explicit state handlers
+- Working with the constraint-based layout system
+
+```rust
+use tessera_ui::{measure_node, place_node, ComputedData, Constraint, PxPosition};
+use tessera_ui_macros::tessera;
+
+#[tessera]
+fn custom_layout() {
+    measure(|input| {
+        let mut total_width = 0;
+        for (i, &child_id) in input.children_ids.iter().enumerate() {
+            let child_size = measure_node(child_id, input.parent_constraint, input.metadatas)?;
+            place_node(child_id, PxPosition::new(total_width.into(), 0.into()), input.metadatas);
+            total_width += child_size.width.to_i32();
+        }
+        Ok(ComputedData::from_size((total_width.into(), input.parent_constraint.height.min_value())))
+    });
+
+    state_handler(|input| {
+        // Handle user interactions here
+    });
+}
+```
+
+🔴 **Advanced Users** - Custom Rendering Pipelines
+
+For developers building custom visual effects and rendering pipelines:
+
+Advanced rendering modules:
+- `renderer::drawer` - Custom drawable pipelines and draw commands
+- `renderer::compute` - GPU compute pipelines for advanced effects
+- `DrawCommand`, `ComputeCommand` - Low-level rendering commands
+- `DrawablePipeline`, `ComputablePipeline` - Pipeline trait implementations
+- `PipelineRegistry`, `ComputePipelineRegistry` - Pipeline management
+
+Key concepts:
+- Creating custom WGPU shaders and pipelines
+- Managing GPU resources and compute operations
+- Understanding the rendering command system
+- Implementing advanced visual effects like lighting, shadows, and particles
+
+```rust
+use tessera_ui::renderer::{DrawCommand, DrawablePipeline};
+use wgpu::{Device, Queue, RenderPass};
+
+struct MyCustomPipeline {
+    // Your pipeline state
+}
+
+impl DrawablePipeline for MyCustomPipeline {
+    fn draw<'a>(&'a self, render_pass: &mut RenderPass<'a>) {
+        // Custom rendering logic
+    }
+}
+```
+
+## Core Modules
+Essential Types and Functions
+- `Renderer` - Main application renderer and lifecycle manager
+- `measure_node`, `place_node` - Core layout functions
+- `Constraint`, `DimensionValue` - Layout constraint system
+- `Dp`, `Px` - Measurement units (device-independent and pixel units)
+- `Color` - Color representation and utilities
+
+Component System
+- `ComponentTree` - Component tree management
+- `ComponentNode` - Individual component node representation
+- `ComputedData` - Layout computation results
+- `StateHandlerFn` - State management and event handling
+
+Event Handling
+- `CursorEvent` - Mouse and touch input events
+- `Focus` - Focus management system
+- `PressKeyEventType` - Keyboard input handling
+
+Rendering System
+- `renderer::drawer` - Drawing pipeline system
+- `renderer::compute` - Compute pipeline system
+- `DrawCommand`, `ComputeCommand` - Rendering commands
+
+## Examples
+
+Check out the example crate in the workspace for comprehensive examples demonstrating:
+- Basic component usage
+- Custom layouts and interactions
+- Advanced shader effects
+- Cross-platform deployment (Windows, Linux, macOS, Android)
+
+## Performance Considerations
+
+Tessera is designed for high performance through:
+- Parallel measurement computation using Rayon
+- Efficient GPU utilization through custom shaders
+- Minimal allocations in hot paths
+- Optimized component tree traversal

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,22 +1,43 @@
 ---
-# https://vitepress.dev/reference/default-theme-home-page
 layout: home
 
 hero:
   name: "Tessera"
   text: "A <span class='rotating-words'><span>declarative</span><span>immediate-mode</span><span>parallelized</span><span>cross-platform</span><span>shader-first</span></span><br>UI framework for Rust"
+  tagline: "Build next-generation interfaces in Rust with GPU-first performance and a modern, ergonomic component model."
   actions:
     - theme: brand
       text: Get Started
-      link: /quick-start/what-is-tessera
+      link: /guide/getting-started
+    - theme: alt
+      text: Source Code
+      link: https://github.com/tessera-ui/tessera
 
 features:
-  - title: Declarative Component Model
-    details: Define and compose components using simple functions with the &#35;[tessera] macro, resulting in clean and intuitive code.
-  - title: Powerful and Flexible Layout System
-    details: A constraint-based (Fixed, Wrap, Fill) layout engine, combined with components like row, boxed, and column, makes it easy to implement responsive layouts from simple to complex.
-  - title: Shader-first
-    details: Shaders are first-class citizens in Tessera. You can naturally implement any effect at any time, even using the GPU for general-purpose computing.
-  - title: Highly Parallelized
-    details: Due to its immediate-mode nature, Tessera's rendering and layout methods allow for full utilization of modern multi-core CPUs, delivering exceptional performance.
+  - icon: 🧩
+    title: Declarative Component Model
+    details: Define and compose components using simple functions with the <code>&#35;[tessera]</code> macro, resulting in clean, intuitive, and Rust-idiomatic code.
+  - icon: 📐
+    title: Powerful and Flexible Layout System
+    details: A constraint-based layout engine (Fixed, Wrap, Fill) plus components like <code>row</code>, <code>boxed</code>, and <code>column</code> make responsive layouts effortless.
+  - icon: 🎨
+    title: Shader-first
+    details: Shaders are first-class citizens in Tessera. Implement custom effects at any stage, or harness the GPU for general-purpose computing.
+  - icon: ⚡
+    title: Highly Parallelized
+    details: Immediate-mode rendering and layout leverage modern multi-core CPUs, ensuring exceptional scalability and performance.
+  - icon: 🖥️
+    title: Cross-Platform
+    details: Works across Windows, macOS, and Linux — making Tessera the right choice for both desktop and embedded UI applications.
+  - icon: 🚀
+    title: Future-Ready
+    details: Designed with extensibility and experimentation in mind, Tessera is not just another UI toolkit — it’s a playground for next-gen interface design.
 ---
+
+<hr>
+<div style="display: flex; justify-content: center; align-items: center;">
+    Licensed under the MIT or Apache-2.0 at your option.
+</div>
+<div style="display: flex; justify-content: center; align-items: center;">
+    Copyright (©) Tessera
+</div>


### PR DESCRIPTION
I know Tessera is still under active development, but I figure I'd restructure the site to "future-proof" it.

- I added the `guide` folder, for all guide related material, such as "Getting Started" and "What is Tessera?"
- The `about` folder is now reserved for a sort of "About Tessera" style page (`about.md`)
- The home page has been updated with a footer and emoji's to spice up the design a little bit. 

Most documentation I added was pulled from the Tessera docs.